### PR TITLE
Issue 5 Logstash Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **UNDER CONSTRUCTION - DO NOT USE**
 
 The perfSONAR Measurement Archive based on Elasticsearch
+Proxy authentication credentials are stored in /etc/perfsonar/logstash/proxy_auth.json. To add them to perfsonar tasks, just append the line to the "_headers" json array in the archiver specification and set the destination to host/logstash.
 
 ## RPMS for centos7
 ```
@@ -28,3 +29,5 @@ tail -f /var/log/logstash/logstash-plain.log
 
 ##stop container
 docker-compose -f docker-compose.qa.yml down -v 
+
+

--- a/config/apache/archive/apache-logstash.conf
+++ b/config/apache/archive/apache-logstash.conf
@@ -1,0 +1,23 @@
+<IfModule proxy_module>
+    ProxyRequests Off
+    <Proxy *>
+        <IfVersion >= 2.4>
+            Require all granted
+        </IfVersion>
+        <IfVersion < 2.4>
+            Order deny,allow
+            Allow from all
+        </IfVersion>
+    </Proxy>
+
+    ProxyPass /logstash http://localhost:11283 status=+I
+    ProxyPassReverse /logstash http://localhost:11283 status=+I
+    ProxyPreserveHost On
+
+    <Location /logstash>
+        Authtype Basic
+        Authname "Logstash Pass"
+        AuthUserFile /etc/perfsonar/opensearch/logstash_login
+        Require valid-user
+    </Location>
+</IfModule>

--- a/perfsonar-archive.spec
+++ b/perfsonar-archive.spec
@@ -94,6 +94,7 @@ fi
 %{setup_base}/users/*
 %{setup_base}/index_template-pscheduler.json
 %attr(0644, perfsonar, perfsonar) %{httpd_config_base}/apache-opensearch.conf
+%attr(0644, perfsonar, perfsonar) %{httpd_config_base}/apache-logstash.conf
 
 %changelog
 * Thu Feb 15 2022 luan.rios@rnp.br 5.0.0-0.0.a1


### PR DESCRIPTION
This PR adds the httpd conf file for the logstash reverse proxy with authentication and changes the archive package to create and store the credentials of the valid user perfsonar in the file /etc/perfsonar/logstash/proxy_auth.json. It's necessary to have the PR of the logstash package for this one to work correctly. Please revise it Andy and Daniel.