### PR TITLE
Fix opensearch upgrade

### DIFF
--- a/perfsonar-archive/perfsonar-archive/unibuild-packaging/rpm/perfsonar-archive.spec
+++ b/perfsonar-archive/perfsonar-archive/unibuild-packaging/rpm/perfsonar-archive.spec
@@ -18,7 +18,7 @@ URL:			http://www.perfsonar.net
 Source0:		perfsonar-archive-%{version}.tar.gz
 BuildRoot:		%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:		noarch
-Requires:		opensearch
+Requires:		opensearch >= 2.1.0
 Requires:       java-11-openjdk
 Requires:       openssl
 Requires:       jq

--- a/perfsonar-archive/perfsonar-archive/unibuild-packaging/rpm/perfsonar-archive.spec
+++ b/perfsonar-archive/perfsonar-archive/unibuild-packaging/rpm/perfsonar-archive.spec
@@ -83,6 +83,9 @@ if [ "$1" = "1" ]; then
     #Enable and restart apache for reverse proxy
     systemctl enable httpd
     systemctl restart httpd
+elif [ $1 == 2 ];then
+    #if rpm is getting upgraded, (re)start opensearch
+    systemctl restart opensearch.service
 fi
 
 %preun

--- a/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/rpm/perfsonar-dashboards.spec
+++ b/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/rpm/perfsonar-dashboards.spec
@@ -17,7 +17,7 @@ URL:			http://www.perfsonar.net
 Source0:		perfsonar-dashboards-%{version}.tar.gz
 BuildRoot:		%{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 BuildArch:		noarch
-Requires:       opensearch-dashboards
+Requires:       opensearch-dashboards >= 2.1.0
 Requires:       httpd
 Requires:       mod_ssl
 

--- a/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/rpm/perfsonar-dashboards.spec
+++ b/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/rpm/perfsonar-dashboards.spec
@@ -55,6 +55,9 @@ if [ "$1" = "1" ]; then
     #Enable and restart apache for reverse proxy
     systemctl enable httpd
     systemctl restart httpd
+elif [ $1 == 2 ];then
+    #if rpm is getting upgraded, (re)start opensearch-dashboards
+    systemctl restart opensearch-dashboards.service
 fi
 
 %preun


### PR DESCRIPTION
Restarting opensearch and opensearch-dashboards services during an update as they are not restarted automatically. Also, defining a minimum supported version of these packages.