### PR TITLE
18 opensearch is throwing error about too many shards

### DIFF
--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -24,7 +24,7 @@ COPY . /app
 
 #Build RPM
 RUN cd /app && \
-    make dist && \
+    #make dist && \
     # opensearch and logstash
     mv perfsonar-archive-*.tar.gz ~/rpmbuild/SOURCES/ && \
     rpmbuild -bs perfsonar-archive.spec && \

--- a/perfsonar-archive/perfsonar-archive/config/ilm/install/pscheduler_default_policy.json
+++ b/perfsonar-archive/perfsonar-archive/config/ilm/install/pscheduler_default_policy.json
@@ -9,9 +9,6 @@
           {
             "index_priority": {
               "priority": 100
-            },
-            "rollover": {
-              "min_index_age": "7d"
             }
           }
         ],

--- a/perfsonar-archive/perfsonar-archive/config/ilm/install/pscheduler_default_policy.json
+++ b/perfsonar-archive/perfsonar-archive/config/ilm/install/pscheduler_default_policy.json
@@ -16,7 +16,7 @@
           {
             "state_name": "warm",
             "conditions": {
-              "min_index_age": "25h"
+              "min_index_age": "7d"
             }
           }
         ]

--- a/perfsonar-archive/perfsonar-archive/config/ilm/install/pscheduler_default_policy.json
+++ b/perfsonar-archive/perfsonar-archive/config/ilm/install/pscheduler_default_policy.json
@@ -9,6 +9,9 @@
           {
             "index_priority": {
               "priority": 100
+            },
+            "rollover": {
+              "min_index_age": "7d"
             }
           }
         ],

--- a/perfsonar-archive/perfsonar-archive/config/index_template-auditlog.json
+++ b/perfsonar-archive/perfsonar-archive/config/index_template-auditlog.json
@@ -1,0 +1,11 @@
+{
+  "index_patterns": [
+    "security-auditlog*"
+  ],
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0
+    }
+  }
+}

--- a/perfsonar-archive/perfsonar-archive/config/index_template-opendistro-ism.json
+++ b/perfsonar-archive/perfsonar-archive/config/index_template-opendistro-ism.json
@@ -1,0 +1,11 @@
+{
+  "index_patterns": [
+    ".opendistro-ism-managed-index-history*"
+  ],
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0
+    }
+  }
+}

--- a/perfsonar-archive/perfsonar-archive/config/index_template-pscheduler.json
+++ b/perfsonar-archive/perfsonar-archive/config/index_template-pscheduler.json
@@ -3,6 +3,10 @@
     "pscheduler_*"
   ],
   "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 0
+    },
     "mappings": {
       "_source": {},
       "_meta": {},

--- a/perfsonar-archive/perfsonar-archive/config/index_template-pscheduler.json
+++ b/perfsonar-archive/perfsonar-archive/config/index_template-pscheduler.json
@@ -7,6 +7,9 @@
       "number_of_shards": 1,
       "number_of_replicas": 0
     },
+    "aliases": {
+      "pscheduler": {}
+    },
     "mappings": {
       "_source": {},
       "_meta": {},

--- a/perfsonar-archive/perfsonar-archive/config/index_template-pscheduler.json
+++ b/perfsonar-archive/perfsonar-archive/config/index_template-pscheduler.json
@@ -51,5 +51,6 @@
       ],
       "properties": {}
     }
-  }
+  },
+  "data_stream": {}
 }

--- a/perfsonar-archive/perfsonar-archive/opensearch-scripts/pselastic_secure_pos.sh
+++ b/perfsonar-archive/perfsonar-archive/opensearch-scripts/pselastic_secure_pos.sh
@@ -53,7 +53,8 @@ fi
 # Configure index template for pscheduler index patterns
 echo "[Create template]"
 # Update template
-curl -k -u admin:${ADMIN_PASS} -H 'Content-Type: application/json' -XPUT "https://localhost:9200/_index_template/pscheduler_default_policy" -d @/usr/lib/perfsonar/archive/config/index_template-pscheduler.json
+curl -k -u admin:${ADMIN_PASS} -s -H 'Content-Type: application/json' -XPUT "https://localhost:9200/_index_template/pscheduler_default_policy" -d @/usr/lib/perfsonar/archive/config/index_template-pscheduler.json
+echo ""
 status=$(curl -k -u admin:${ADMIN_PASS} -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" -XPUT "https://localhost:9200/pscheduler*/_settings" -d '{"index" : {"number_of_replicas" : 0}}')
 if [ $status -eq 200 ]; then
     echo "[Index pscheduler updated successfully]"
@@ -64,14 +65,16 @@ echo ""
 # Disabling opensearch internal indexes replicas
 echo "[Update internal indexes]"
 # Configure index template for security-auditlog index pattern
-curl -k -u admin:${ADMIN_PASS} -H 'Content-Type: application/json' -XPUT "https://localhost:9200/_index_template/auditlog" -d @/usr/lib/perfsonar/archive/config/index_template-auditlog.json
+curl -k -u admin:${ADMIN_PASS} -s -H 'Content-Type: application/json' -XPUT "https://localhost:9200/_index_template/auditlog" -d @/usr/lib/perfsonar/archive/config/index_template-auditlog.json
+echo ""
 status=$(curl -k -u admin:${ADMIN_PASS} -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" -XPUT "https://localhost:9200/security-auditlog*/_settings" -d '{"index" : {"number_of_replicas" : 0}}')
 if [ $status -eq 200 ]; then
     echo "[Index security-auditlog updated successfully]"
 fi
 
 # Configure index template for opendistro-ism index pattern
-curl -k -u admin:${ADMIN_PASS} -H 'Content-Type: application/json' -XPUT "https://localhost:9200/_index_template/opendistro_ism" -d @/usr/lib/perfsonar/archive/config/index_template-opendistro-ism.json
+curl -k -u admin:${ADMIN_PASS} -s -H 'Content-Type: application/json' -XPUT "https://localhost:9200/_index_template/opendistro_ism" -d @/usr/lib/perfsonar/archive/config/index_template-opendistro-ism.json
+echo ""
 status=$(curl -k -u admin:${ADMIN_PASS} -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" -XPUT "https://localhost:9200/.opendistro-ism-managed-index-history*/_settings" -d '{"index" : {"number_of_replicas" : 0}}')
 if [ $status -eq 200 ]; then
     echo "[Index opendistro-ism-managed-index-history updated successfully]"

--- a/perfsonar-archive/perfsonar-archive/opensearch-scripts/pselastic_secure_pos.sh
+++ b/perfsonar-archive/perfsonar-archive/opensearch-scripts/pselastic_secure_pos.sh
@@ -54,7 +54,10 @@ fi
 echo "[Create template]"
 # Update template
 curl -k -u admin:${ADMIN_PASS} -H 'Content-Type: application/json' -XPUT "https://localhost:9200/_index_template/pscheduler_default_policy" -d @/usr/lib/perfsonar/archive/config/index_template-pscheduler.json
-curl -k -u admin:${ADMIN_PASS} -H "Content-Type: application/json" -XPUT "https://localhost:9200/pscheduler*/_settings" -d '{"index" : {"number_of_replicas" : 0}}'
+status=$(curl -k -u admin:${ADMIN_PASS} -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" -XPUT "https://localhost:9200/pscheduler*/_settings" -d '{"index" : {"number_of_replicas" : 0}}')
+if [ $status -eq 200 ]; then
+    echo "[Index pscheduler updated successfully]"
+fi
 echo -e "\n[DONE]"
 echo ""
 
@@ -62,10 +65,16 @@ echo ""
 echo "[Update internal indexes]"
 # Configure index template for security-auditlog index pattern
 curl -k -u admin:${ADMIN_PASS} -H 'Content-Type: application/json' -XPUT "https://localhost:9200/_index_template/auditlog" -d @/usr/lib/perfsonar/archive/config/index_template-auditlog.json
-curl -k -u admin:${ADMIN_PASS} -H "Content-Type: application/json" -XPUT "https://localhost:9200/security-auditlog*/_settings" -d '{"index" : {"number_of_replicas" : 0}}'
+status=$(curl -k -u admin:${ADMIN_PASS} -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" -XPUT "https://localhost:9200/security-auditlog*/_settings" -d '{"index" : {"number_of_replicas" : 0}}')
+if [ $status -eq 200 ]; then
+    echo "[Index security-auditlog updated successfully]"
+fi
 
 # Configure index template for opendistro-ism index pattern
 curl -k -u admin:${ADMIN_PASS} -H 'Content-Type: application/json' -XPUT "https://localhost:9200/_index_template/opendistro_ism" -d @/usr/lib/perfsonar/archive/config/index_template-opendistro-ism.json
-curl -k -u admin:${ADMIN_PASS} -H "Content-Type: application/json" -XPUT "https://localhost:9200/.opendistro-ism-managed-index-history*/_settings" -d '{"index" : {"number_of_replicas" : 0}}'
+status=$(curl -k -u admin:${ADMIN_PASS} -s -o /dev/null -w "%{http_code}" -H "Content-Type: application/json" -XPUT "https://localhost:9200/.opendistro-ism-managed-index-history*/_settings" -d '{"index" : {"number_of_replicas" : 0}}')
+if [ $status -eq 200 ]; then
+    echo "[Index opendistro-ism-managed-index-history updated successfully]"
+fi
 echo -e "\n[DONE]"
 echo ""

--- a/perfsonar-archive/perfsonar-archive/unibuild-packaging/deb/perfsonar-archive.install
+++ b/perfsonar-archive/perfsonar-archive/unibuild-packaging/deb/perfsonar-archive.install
@@ -2,5 +2,7 @@ config/ilm/* /usr/lib/perfsonar/archive/config/ilm/
 config/roles/* /usr/lib/perfsonar/archive/config/roles/
 config/users/* /usr/lib/perfsonar/archive/config/users/
 config/index_template-pscheduler.json /usr/lib/perfsonar/archive/config/
+config/index_template-auditlog.json /usr/lib/perfsonar/archive/config/
+config/index_template-opendistro-ism.json /usr/lib/perfsonar/archive/config/
 config/apache/* /etc/apache2/conf-available/
 opensearch-scripts/* /usr/lib/perfsonar/archive/perfsonar-scripts/

--- a/perfsonar-archive/perfsonar-archive/unibuild-packaging/deb/perfsonar-archive.postinst
+++ b/perfsonar-archive/perfsonar-archive/unibuild-packaging/deb/perfsonar-archive.postinst
@@ -55,6 +55,8 @@ case "$1" in
         else
             #upgrade
             service opensearch restart
+            # Opensearch post startup script
+            bash /usr/lib/perfsonar/archive/perfsonar-scripts/pselastic_secure_pos.sh
         fi
     ;;
 

--- a/perfsonar-archive/perfsonar-archive/unibuild-packaging/rpm/perfsonar-archive.spec
+++ b/perfsonar-archive/perfsonar-archive/unibuild-packaging/rpm/perfsonar-archive.spec
@@ -79,8 +79,6 @@ if [ "$1" = "1" ]; then
     systemctl start opensearch.service
     #restart logstash
     systemctl restart logstash.service
-    #run opensearch post startup script
-    bash %{scripts_base}/pselastic_secure_pos.sh
     #run elmond configuration script
     bash %{scripts_base}/elmond_configuration.sh
     usermod -a -G opensearch perfsonar
@@ -92,6 +90,8 @@ if [ "$1" = "1" ]; then
     #set SELinux booleans to allow httpd proxy to work
     %selinux_set_booleans -s %{selinuxtype} %{selinuxbooleans}
 fi
+#run opensearch post startup script
+bash %{scripts_base}/pselastic_secure_pos.sh
 
 %preun
 %systemd_preun opensearch.service

--- a/perfsonar-archive/perfsonar-archive/unibuild-packaging/rpm/perfsonar-archive.spec
+++ b/perfsonar-archive/perfsonar-archive/unibuild-packaging/rpm/perfsonar-archive.spec
@@ -110,6 +110,8 @@ fi
 %{setup_base}/roles/*
 %{setup_base}/users/*
 %{setup_base}/index_template-pscheduler.json
+%{setup_base}/index_template-auditlog.json
+%{setup_base}/index_template-opendistro-ism.json
 %attr(0644, perfsonar, perfsonar) %{httpd_config_base}/apache-opensearch.conf
 # Set to config so users can update auth settings
 %config(noreplace) %attr(0644, perfsonar, perfsonar) %{httpd_config_base}/apache-logstash.conf


### PR DESCRIPTION
Updating the number of replicas from 1 to 0 for pscheduler indices and opensearch internal indices.
Changing pscheduler template to data stream.
Updating the minimum age of hot indices from 25 hours to 7 days.