### PR TITLE
Removing references to elmond systemd service

### DIFF
--- a/perfsonar-archive/perfsonar-archive/unibuild-packaging/deb/perfsonar-archive.postinst
+++ b/perfsonar-archive/perfsonar-archive/unibuild-packaging/deb/perfsonar-archive.postinst
@@ -38,8 +38,6 @@ case "$1" in
             # Elmond configuration script
             bash /usr/lib/perfsonar/archive/perfsonar-scripts/elmond_configuration.sh
             usermod -a -G opensearch perfsonar
-            # Restart Elmond
-            systemctl restart elmond
 
             # Apache setup
             if [ -e /usr/share/apache2/apache2-maintscript-helper ]; then

--- a/perfsonar-archive/perfsonar-archive/unibuild-packaging/rpm/perfsonar-archive.spec
+++ b/perfsonar-archive/perfsonar-archive/unibuild-packaging/rpm/perfsonar-archive.spec
@@ -83,8 +83,6 @@ if [ "$1" = "1" ]; then
     #run elmond configuration script
     bash %{scripts_base}/elmond_configuration.sh
     usermod -a -G opensearch perfsonar
-    #restart elmond
-    systemctl restart elmond.service
     #Enable and restart apache for reverse proxy
     systemctl enable httpd
     systemctl restart httpd


### PR DESCRIPTION
This PR addresses the issue perfsonar/elmond#15

Changes:

- Deleted all references to the elmond systemd service.

Testing:

- Verified that the Archive installs and runs correctly across all supported operating systems:
  - Rocky 9
  - Alma 9
  - Debian 11
  - Debian 12
  - Ubuntu 20.04
  - Ubuntu 22.04