### PR TITLE
Update perfsonar-dashboards.postinst

### DIFF
--- a/perfsonar-dashboards/perfsonar-dashboards/dashboards-scripts/dashboards_secure_pos.sh
+++ b/perfsonar-dashboards/perfsonar-dashboards/dashboards-scripts/dashboards_secure_pos.sh
@@ -22,7 +22,12 @@ done
 echo "API started!"
 
 # Pre configure opensearch dashboards's index patterns
-echo "[Add default index-pattern]"
-curl -X POST -u admin:${ADMIN_PASS} http://localhost:5601/api/saved_objects/index-pattern -H "osd-version: ${DASHBOARDS_VERSION}" -H "osd-xsrf: true" -H "content-type: application/json; charset=utf-8" -d '{"attributes":{"title":"pscheduler*","timeFieldName":"pscheduler.start_time","fields":"[]"}}' 2>/dev/null
-echo -e "\n[DONE]"
-echo ""
+# Check if the index pattern already exists
+response=$(curl -s -X GET -u admin:${ADMIN_PASS} "http://localhost:5601/api/saved_objects/_find?type=index-pattern&search_fields=title&search=pscheduler")
+total=$(echo "$response" | jq -r '.total')
+if [[ "$total" -eq 0 ]]; then
+    echo "[Add default index-pattern]"
+    curl -X POST -u admin:${ADMIN_PASS} http://localhost:5601/api/saved_objects/index-pattern -H "osd-version: ${DASHBOARDS_VERSION}" -H "osd-xsrf: true" -H "content-type: application/json; charset=utf-8" -d '{"attributes":{"title":"pscheduler*","timeFieldName":"pscheduler.start_time","fields":"[]"}}' 2>/dev/null
+    echo -e "\n[DONE]"
+    echo ""
+fi

--- a/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/deb/control
+++ b/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/deb/control
@@ -9,7 +9,7 @@ Homepage: http://www.perfsonar.net
 Package: perfsonar-dashboards
 Architecture: all
 Depends: ${shlibs:Depends}, ${misc:Depends}, opensearch-dashboards, apache2,
- apache2-ssl-dev, perfsonar-common
+ apache2-ssl-dev, jq, perfsonar-common
 Description: perfSONAR archive dashboards
  A package that installs and configure Opensearch Dashboards for
  perfSONAR usage and accessing the Opensearch based perfSONAR Archive.

--- a/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/deb/perfsonar-dashboards.postinst
+++ b/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/deb/perfsonar-dashboards.postinst
@@ -7,6 +7,8 @@ set -e
 
 case "$1" in
     configure)
+        # check if installation or update, where version is a parameter
+        if [ -z "$2" ]; then
             #enable opensearch-dashboards service
             systemctl enable opensearch-dashboards
             #run opensearch dashboards pre startup script
@@ -15,8 +17,6 @@ case "$1" in
             systemctl start opensearch-dashboards
             #run opensearch dashboards post startup script
             bash /usr/lib/perfsonar/dashboards/dashboards-scripts/dashboards_secure_pos.sh
-            #restart opensearch
-            systemctl restart opensearch
 
             # Apache setup
             if [ -e /usr/share/apache2/apache2-maintscript-helper ]; then
@@ -27,6 +27,14 @@ case "$1" in
                 # Only doing a restart once to avoid triggering limits
                 apache2_invoke enmod proxy_http restart
             fi
+        else
+            #run opensearch dashboards pre startup script
+            bash /usr/lib/perfsonar/dashboards/dashboards-scripts/dashboards_secure_pre.sh
+            #if deb is getting upgraded, (re)start opensearch-dashboards
+            systemctl restart opensearch-dashboards
+            #run opensearch dashboards post startup script
+            bash /usr/lib/perfsonar/dashboards/dashboards-scripts/dashboards_secure_pos.sh
+        fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/deb/perfsonar-dashboards.postinst
+++ b/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/deb/perfsonar-dashboards.postinst
@@ -7,8 +7,6 @@ set -e
 
 case "$1" in
     configure)
-        # check if installation or update, where version is a parameter
-        if [ -z "$2" ]; then
             #enable opensearch-dashboards service
             systemctl enable opensearch-dashboards
             #run opensearch dashboards pre startup script
@@ -17,6 +15,8 @@ case "$1" in
             systemctl start opensearch-dashboards
             #run opensearch dashboards post startup script
             bash /usr/lib/perfsonar/dashboards/dashboards-scripts/dashboards_secure_pos.sh
+            #restart opensearch
+            systemctl restart opensearch
 
             # Apache setup
             if [ -e /usr/share/apache2/apache2-maintscript-helper ]; then
@@ -27,10 +27,6 @@ case "$1" in
                 # Only doing a restart once to avoid triggering limits
                 apache2_invoke enmod proxy_http restart
             fi
-        else
-            #upgrade
-            systemctl restart opensearch
-        fi
     ;;
 
     abort-upgrade|abort-remove|abort-deconfigure)

--- a/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/rpm/perfsonar-dashboards.spec
+++ b/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/rpm/perfsonar-dashboards.spec
@@ -20,6 +20,7 @@ BuildArch:		noarch
 Requires:       opensearch-dashboards >= 2.1.0
 Requires:       httpd
 Requires:       mod_ssl
+Requires:       jq
 
 %description
 A package that installs and configure Opensearch Dashboards.

--- a/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/rpm/perfsonar-dashboards.spec
+++ b/perfsonar-dashboards/perfsonar-dashboards/unibuild-packaging/rpm/perfsonar-dashboards.spec
@@ -57,8 +57,12 @@ if [ "$1" = "1" ]; then
     systemctl enable httpd
     systemctl restart httpd
 elif [ $1 == 2 ];then
+    #run opensearch dashboards pre startup script
+    bash %{scripts_base}/dashboards_secure_pre.sh
     #if rpm is getting upgraded, (re)start opensearch-dashboards
     systemctl restart opensearch-dashboards.service
+    #run opensearch dashboards post startup script
+    bash %{scripts_base}/dashboards_secure_pos.sh
 fi
 
 %preun


### PR DESCRIPTION
This script does not work during the 5.1 to 5.2 upgrade. The issue is caused by the -z "$2" condition in this line "if [ -z "$2" ]; then". In my opinion, we don’t need this line at all. Additionally, we can restart OpenSearch in the previous segment. 

It would be better if the developer looked into it, maybe there is another option which would be better.